### PR TITLE
i18n service

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@inveniosoftware/invenio-e2e",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "tsc; cp package.json dist",
     "docs": "documentation build src/**/*.ts -f md -o api_docs.md --shallow --github --sort-order kind"
@@ -15,12 +15,15 @@
     "@playwright/test": "^1.54.1",
     "@types/node": "^24.0.13",
     "documentation": "^14.0.3",
+    "ts-deepmerge": "^7.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
-    "ts-deepmerge": "^7.0.3"
+    "typescript": "^5.8.3"
   },
   "peerDependencies": {
     "@playwright/test": "^1.54.1",
     "ts-deepmerge": "^7.0.3"
+  },
+  "dependencies": {
+    "i18next": "^25.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,12 @@
     "documentation": "^14.0.3",
     "ts-deepmerge": "^7.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "i18next": "^25.3.2"
   },
   "peerDependencies": {
     "@playwright/test": "^1.54.1",
-    "ts-deepmerge": "^7.0.3"
-  },
-  "dependencies": {
+    "ts-deepmerge": "^7.0.3",
     "i18next": "^25.3.2"
   }
 }

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -3,6 +3,7 @@ import { Expect, test as base, expect as playwrightExpect } from '@playwright/te
 import { I18nExpected, I18nService, LocalLoginService, Services, Translations } from '../services';
 
 import type { Locators } from '../locators';
+import { TextCaptureOptions } from '../utils/textCapture';
 import { locators } from '../locators';
 import { registerPage } from './utils';
 
@@ -15,6 +16,7 @@ export const test = base.extend<{
     initialLocale: string;
     translations: Translations;
     excludes: string[];
+    translatableSelectors: string[];
 
     i18nService: I18nService<Locators>;
     loginService: LocalLoginService<Locators>;
@@ -40,11 +42,71 @@ export const test = base.extend<{
     // initial locale (do not limit the locale by default)
     initialLocale: undefined,
 
-    // translations for i18n service - I18nService now provides its own defaults
-    translations: {},
+    // translations for i18n service with sensible defaults
+    translations: {
+        'test': {
+            'en': { 'repository.welcome': 'Welcome to InvenioRDM\'s Sandbox!' },
+            'de': { 'repository.welcome': 'Willkommen in InvenioRDMs Sandbox!' },
+            'cs': { 'repository.welcome': 'Vítejte v InvenioRDM Sandbox!' }
+        },
+        // Placeholder catalogue - institutions would provide real translations
+        'invenio-app-rdm-messages': {
+            'en': { 
+                'repository.name': 'InvenioRDM Repository',
+                'search.placeholder': 'Search records...',
+                'nav.home': 'Home',
+                'nav.search': 'Search'
+            },
+            'de': { 
+                'repository.name': 'InvenioRDM Repository',
+                'search.placeholder': 'Datensätze suchen...',
+                'nav.home': 'Startseite', 
+                'nav.search': 'Suchen'
+            }
+        }
+    },
 
     // excludes for translation testing 
     excludes: [],
+
+    // selectors for elements that should be translatable
+    translatableSelectors: [
+        "nav a:not(:empty)",
+        "nav button:not(:empty)",
+        "nav span:not(:empty)",
+        ".navbar a:not(:empty)",
+        ".navbar button:not(:empty)",
+        ".navbar span:not(:empty)",
+        "header a:not(:empty)",
+        "header button:not(:empty)",
+        "header span:not(:empty)",
+
+        "label:not(:empty)",
+        ".form-label:not(:empty)",
+        "legend:not(:empty)",
+        "button:not(:empty)",
+        'input[type="submit"][value]',
+
+        "h1:not(:empty)",
+        "h2:not(:empty)",
+        "h3:not(:empty)",
+        "h4:not(:empty)",
+        "h5:not(:empty)",
+        "h6:not(:empty)",
+        ".alert:not(:empty)",
+        ".error:not(:empty)",
+        ".warning:not(:empty)",
+        ".success:not(:empty)",
+        ".help-text:not(:empty)",
+        ".tooltip:not(:empty)",
+
+        '[role="menuitem"]:not(:empty)',
+        '[role="tab"]:not(:empty)',
+        '[role="button"]:not(:empty)',
+        ".menu-item:not(:empty)",
+        ".tab-label:not(:empty)",
+        ".btn:not(:empty)",
+    ],
 
     // browser context with initial locale
     context: async ({ context: originalContext, initialLocale }, use) => {
@@ -55,8 +117,8 @@ export const test = base.extend<{
         await use(originalContext);
     },
 
-    i18nService: async ({ page, locators, initialLocale, translations }, use) => {
-        const i18nService = new I18nService(page, locators, initialLocale, translations);
+    i18nService: async ({ page, locators, initialLocale, translations, excludes, translatableSelectors }, use) => {
+        const i18nService = new I18nService(page, locators, initialLocale, translations, excludes, translatableSelectors);
         await use(i18nService);
     },
 
@@ -73,7 +135,7 @@ export const test = base.extend<{
     },
 
     expect: async ({ i18nService }, use) => {
-        // TODO: find a type safe way to extend the expect multiple times
+        // serviceA.extendExpected(serviceB.extendExpected(playwrightExpected))
         await use(i18nService.extendExpect(playwrightExpect));
     },
 

--- a/src/fixtures/utils.ts
+++ b/src/fixtures/utils.ts
@@ -10,10 +10,9 @@ import { Services, I18nExpected } from '../services';
 export type PageFixtureParams<L extends Locators> = {
     page: Page;
     locators: L;
-    availablePages: { [key: string]: object };
+    availablePages: { [key: string]: BasePage };
     services: Services<L>;
     expect: Expect<I18nExpected>;
-    excludes: string[];
 }
 
 /**
@@ -93,7 +92,6 @@ export function registerPage<L extends Locators, T extends typeof BasePage<L>>(
             "availablePages",
             "services",
             "expect",
-            "excludes",
             ...options.extraFixtures, // extra fixtures are passed as parameters
         ].join(", ");
         const func = eval(`async ({ ${parameters} } , use) => { return await page_creator({ ${parameters} }, use); }`);
@@ -103,8 +101,8 @@ export function registerPage<L extends Locators, T extends typeof BasePage<L>>(
     }
 
     return {
-        [name]: async ({ page, locators, availablePages, services, expect, excludes }: PageFixtureParams<L>, use: UseFunction<L, T>) => {
-            await page_creator({ page, locators, availablePages, services, expect, excludes }, use)
+        [name]: async ({ page, locators, availablePages, services, expect }: PageFixtureParams<L>, use: UseFunction<L, T>) => {
+            await page_creator({ page, locators, availablePages, services, expect }, use)
         }
     }
 }

--- a/src/fixtures/utils.ts
+++ b/src/fixtures/utils.ts
@@ -1,7 +1,7 @@
 import { Page, Expect } from '@playwright/test';
-import type { Locators } from '../locators';
-import { BasePage } from '../pages';
-import { Services, I18nExpect } from '../services';
+import { Locators } from '../locators';
+import { BasePage } from '../pages/basePage';
+import { Services, I18nExpected } from '../services';
 
 /**
  * PageFixtureParams defines the parameters required to create a page instance.
@@ -12,7 +12,8 @@ export type PageFixtureParams<L extends Locators> = {
     locators: L;
     availablePages: { [key: string]: object };
     services: Services<L>;
-    expect: Expect<I18nExpect>;
+    expect: Expect<I18nExpected>;
+    excludes: string[];
 }
 
 /**
@@ -92,6 +93,7 @@ export function registerPage<L extends Locators, T extends typeof BasePage<L>>(
             "availablePages",
             "services",
             "expect",
+            "excludes",
             ...options.extraFixtures, // extra fixtures are passed as parameters
         ].join(", ");
         const func = eval(`async ({ ${parameters} } , use) => { return await page_creator({ ${parameters} }, use); }`);
@@ -101,8 +103,8 @@ export function registerPage<L extends Locators, T extends typeof BasePage<L>>(
     }
 
     return {
-        [name]: async ({ page, locators, availablePages, services, expect }: PageFixtureParams<L>, use: UseFunction<L, T>) => {
-            await page_creator({ page, locators, availablePages, services, expect }, use)
+        [name]: async ({ page, locators, availablePages, services, expect, excludes }: PageFixtureParams<L>, use: UseFunction<L, T>) => {
+            await page_creator({ page, locators, availablePages, services, expect, excludes }, use)
         }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,25 @@
 // test runner
-export * from './fixtures';
-export * from './pages';
-export * from './locators';
-export * from './services';
-export * from './utils';
-
-// default locators
-export { locators, Locators, updateLocators } from "./locators";
+export { test, InvenioTest, registerPage } from './fixtures';
 
 // pages
-export { HomePage } from './pages/homePage';
-export { SearchPage } from './pages/searchPage';
-export { BasePage } from './pages/basePage';
+export { BasePage, HomePage, SearchPage } from './pages';
+
+// locators
+export { locators, Locators, updateLocators } from "./locators";
+
+// services
+export { 
+    I18nService, 
+    I18nServiceInterface, 
+    I18nExpected, 
+    Translations, 
+    LocalLoginService, 
+    LoginServiceInterface, 
+    Services 
+} from './services';
+
+// utils
+export { TextCaptureUtil, TextCaptureOptions, TranslatableElement } from './utils';
 
 // tests
 export { homepageTests } from './tests/e2e';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 // test runner
-export {test, registerPage} from './fixtures';
-export type { InvenioTest } from './fixtures';
+export * from './fixtures';
+export * from './pages';
+export * from './locators';
+export * from './services';
+export * from './utils';
 
 // default locators
 export { locators, Locators, updateLocators } from "./locators";

--- a/src/locators/defaultLocators.ts
+++ b/src/locators/defaultLocators.ts
@@ -6,11 +6,22 @@ export const locators = {
     header: {
         logoLink: '#invenio-nav a.logo-link',
     },
+    navigation: {
+        homeLink: 'nav a[href="/"], .navbar a[href="/"], header a[href="/"]',
+        searchLink: 'nav a[href*="search"], .navbar a[href*="search"], header a[href*="search"]',
+    },
     homePage: {
         searchField: 'input[name="q"]',
         searchButton: 'button[type="submit"]',
+        searchPlaceholder: 'input[placeholder]',
+        repositoryName: 'h1, .site-title, .logo-text',
     },
     searchPage: {
         searchResultList: 'section[aria-label="Search results"]',
+        searchInput: '.search-input',
+    },
+    footer: {
+        languageSelector: '.language-selector, .footer .dropdown, .footer [class*="language"]',
+        languageOption: '.dropdown .item, .language-option',
     }
 }

--- a/src/pages/basePage.ts
+++ b/src/pages/basePage.ts
@@ -1,47 +1,51 @@
-import { Page, Expect } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
+import { TextCaptureOptions, TextCaptureUtil, TranslatableElement } from '../utils/textCapture';
+
+import { Expect } from '@playwright/test';
+import { I18nExpected } from '../services/i18n';
 import { Locators } from '../locators';
-import { HomePage } from './homePage';
-import { Services, I18nExpect } from '../services';
+import { Services } from '../services';
 
 /**
  * Class representing a base page with common functionality for all pages.
  */
-export class BasePage<L extends Locators = Locators, S extends Services<L> = Services<L>,
-    ExpectExtension extends I18nExpect = I18nExpect
-> {
+export class BasePage<L extends Locators = Locators> {
     protected page: Page;
     protected locators: L;
-    protected availablePages: { [key: string]: object };
-    protected services: S;
-    protected expect: Expect<ExpectExtension>
+    protected services: Services<L>;
+    protected availablePages: { [key: string]: BasePage };
+    protected expect: Expect<I18nExpected>;
+    protected excludes: string[];
 
     /**
-     * Creates a new instance of the abstract base page.
-     * 
-     * @param page  Playwright Page object representing the current page.
-     * @param locators  An object containing locators for elements on the page.
+     * Base class for page objects in Playwright tests.
+     * @param page            The Playwright page object for browser interactions.
+     * @param locators        An object containing locators for elements on the page.
+     * @param services        An object containing services for interacting with the application.
      * @param availablePages  An object containing available pages for navigation.
      */
-    constructor({ page, locators, availablePages, services, expect }: {
+    constructor({ page, locators, availablePages, services, expect, excludes }: {
         page: Page,
         locators: L,
         availablePages: { [key: string]: object },
-        services: S,
-        expect: Expect<ExpectExtension>
+        services: Services<L>,
+        expect: Expect<I18nExpected>,
+        excludes: string[]
     }) {
         this.page = page;
         this.locators = locators;
-        this.availablePages = availablePages;
+        this.availablePages = availablePages as { [key: string]: BasePage };
         this.services = services;
         this.expect = expect;
+        this.excludes = excludes;
     }
 
-    // VALIDATION
     /**
-     * Validates that the loaded page has a logo link in the header.
+     * Validates that the page has been loaded successfully.
      */
     async validatePageLoaded(): Promise<void> {
-        await this.page.waitForSelector(this.locators.header.logoLink);
+        // Base implementation - subclasses should override with specific validation
+        await this.page.waitForLoadState("networkidle");
     }
 
     /**
@@ -53,17 +57,119 @@ export class BasePage<L extends Locators = Locators, S extends Services<L> = Ser
         await this.expect(logo).toBeVisible();
     }
 
-    // NAVIGATION
     /**
      * Navigates to the home page as we should always have a home page link in the header.
      * 
      * @returns the home page
      */
-    async navigateToHomePage(): Promise<HomePage> {
+    async navigateToHomePage(): Promise<any> {
         const logoLink = await this.page.locator(this.locators.header.logoLink);
         await logoLink.click();
-        const homePage: HomePage = this.availablePages['homePage'] as HomePage;
-        await homePage.validatePageLoaded();
+        const homePage = this.availablePages['homePage'];
+        if (homePage && 'validatePageLoaded' in homePage) {
+            await (homePage as any).validatePageLoaded();
+        }
         return homePage;
+    }
+
+    /** Test specific UI elements against translation keys */
+    async expectElementTranslations(
+        locale: string, 
+        messageCatalogue: string = 'invenio-app-rdm-messages'
+    ): Promise<void> {
+      /* target locale */
+      await this.services.i18n.switchLocale(locale);
+
+      const elements = await TextCaptureUtil.findTranslatableElements(
+        this.page,
+        this.excludes
+      );
+
+      console.log(`\nTranslations (${locale}):`);
+      console.log(`Found ${elements.length} translatable elements`);
+      console.log(`Testing against catalogue: ${messageCatalogue}`);
+
+      let testedCount = 0;
+      let passedCount = 0;
+
+      const commonKeys = [
+        { key: "nav.home", selectors: ["nav a", ".navbar a", "header a"] },
+        { key: "nav.search", selectors: ["nav a", ".navbar a", "header a"] },
+        {
+          key: "search.placeholder",
+          selectors: ["input[placeholder]", ".search-input"],
+        },
+        {
+          key: "repository.name",
+          selectors: ["h1", ".site-title", ".logo-text"],
+        },
+      ];
+
+      for (const { key, selectors } of commonKeys) {
+        if (!this.services.i18n.hasTranslation(key, messageCatalogue, locale)) {
+          console.log(
+            ` No translation found for key "${key}" in catalogue "${messageCatalogue}"`
+          );
+          continue;
+        }
+
+        for (const selector of selectors) {
+          try {
+            const element = this.page.locator(selector).first();
+            if (await element.isVisible({ timeout: 1000 })) {
+              testedCount++;
+              try {
+                await this.expect(element).toHaveI18nText(
+                  key,
+                  messageCatalogue,
+                  { locale }
+                );
+                passedCount++;
+                console.log(`${key}: ${selector}`);
+              } catch (error) {
+                console.log(`${key}: ${selector} - ${error}`);
+              }
+              break; 
+            }
+          } catch {
+            // skip if element not found or not testable
+          }
+        }
+      }
+
+      console.log(
+        `\nResults: ${passedCount}/${testedCount} translations verified`
+      );
+
+      /* if no translatable elements found matching known keys maybe we should check!!! 
+        - translations for common UI elements to ${messageCatalogue}
+        - if elements use expected selectors
+        - verifying exclude patterns are not too restrictive
+      */
+        if (testedCount === 0){}
+    }
+
+    /** Capture text, switch language, compare to find untranslated content */
+    async expectTranslation(
+        fromLang: string, 
+        toLang: string, 
+        options: TextCaptureOptions = {}
+    ): Promise<void> {
+        await this.services.i18n.switchLocale(fromLang);
+        const beforeTexts = await TextCaptureUtil.capture(this.page, this.excludes, options);
+
+        await this.services.i18n.switchLocale(toLang);
+        const afterTexts = await TextCaptureUtil.capture(this.page, this.excludes, options);
+
+        const unchanged = beforeTexts.filter(word => afterTexts.includes(word));
+
+        console.log(`\nTranslation Analysis (${fromLang} → ${toLang}):`);
+        console.log(`Total UI words captured: ${beforeTexts.length}`);
+        console.log(`Untranslated UI words found: ${unchanged.length}`);
+        console.log(`Sample untranslated:`, unchanged.slice(0, 10));
+        
+        if (unchanged.length > 0) {
+            console.log(`Full untranslated list:`, unchanged);
+        }
     }
 }

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -1,30 +1,159 @@
-import { Page, Expect } from '@playwright/test';
-import { Locators } from '../locators';
+import { Expect, Locator, Page, expect } from '@playwright/test';
 
-export interface I18nServiceInterface<L extends Locators> {
-    // TODO: Define methods for the I18nServiceInterface
-    extendExpect(expect: Expect): Expect;
-}
+import type { Locators } from '../locators';
 
-export type I18nExpect = {
-    toHaveI18nText: (received: any, text: string) => Promise<{
+export type I18nExpected = Record<string, any> & {
+    toHaveI18nText(
+        locator: Locator, 
+        translationKey: string, 
+        messageCatalogue?: string, 
+        options?: { locale?: string }
+    ): Promise<{
         pass: boolean;
         message: () => string;
     }>;
 };
 
+export interface Translations {
+    [catalogue: string]: {
+        [locale: string]: {
+            [key: string]: string;
+        };
+    };
+}
+
+/**
+ * Interface for changing languages and checking translations in tests
+ */
+export interface I18nServiceInterface<L extends Locators> {
+    switchLocale(locale: string): Promise<void>;
+    currentLocale: string;
+    extendExpect(expect: Expect): Expect<I18nExpected>;
+    hasTranslation(key: string, messageCatalogue: string, locale?: string): boolean;
+}
+
 export class I18nService<L extends Locators> implements I18nServiceInterface<L> {
+    private page: Page;
+    private locators: L;
+    private _currentLocale: string;
+    private translations: Translations;
+
     constructor(
-        protected page: Page,
-        protected locators: L) { }
-    // methods here
-    extendExpect(expect: Expect): Expect<I18nExpect> {
-        // todo: add matchers here
-        return expect.extend<I18nExpect>({
-            toHaveI18nText: async (received: any, text: string) => {
-                // TODO: implement this
-                return { pass: true, message: () => "" }
+        page: Page,
+        locators: L,
+        initialLocale: string = 'en',
+        translations: Translations = {}
+    ) {
+        this.page = page;
+        this.locators = locators;
+        this._currentLocale = initialLocale;
+        this.translations = translations;
+        
+        if (Object.keys(translations).length === 0) {
+            this.translations = this.getDefaultTranslations();
+        }
+    }
+
+    get currentLocale(): string {
+        return this._currentLocale;
+    }
+
+    /**
+     * Placeholder translations structure matching 
+     * 
+     * Future catalogue loading ideas:
+     * Query installed packages for entry points, generate registry JSON file
+     * Runtime query: fetch(`${baseUrl}/api/translations/catalogs`)
+     */
+    private getDefaultTranslations(): Translations {
+        return {
+            'test': {
+                'en': { 'repository.welcome': 'Welcome to InvenioRDM\'s Sandbox!' },
+                'de': { 'repository.welcome': 'Willkommen in InvenioRDMs Sandbox!' },
+                'cs': { 'repository.welcome': 'Vítejte v InvenioRDM Sandbox!' }
+            },
+            // Placeholder catalogue - institutions would provide real translations
+            'invenio-app-rdm-messages': {
+                'en': { 
+                    'repository.name': 'InvenioRDM Repository',
+                    'search.placeholder': 'Search records...',
+                    'nav.home': 'Home',
+                    'nav.search': 'Search'
+                },
+                'de': { 
+                    'repository.name': 'InvenioRDM Repository',
+                    'search.placeholder': 'Datensätze suchen...',
+                    'nav.home': 'Startseite', 
+                    'nav.search': 'Suchen'
+                }
             }
+        };
+    }
+
+    /** Get list of available translation catalogues */
+    getAvailableCatalogues(): string[] {
+        return Object.keys(this.translations);
+    }
+
+    /** Check if translation exists for a key */
+    hasTranslation(key: string, messageCatalogue: string, locale?: string): boolean {
+        const targetLocale = locale || this._currentLocale;
+        return !!(this.translations[messageCatalogue]?.[targetLocale]?.[key]);
+    }
+
+    /** Get translated text for a key */
+    get_localized_text(key: string, messageCatalogue: string, locale?: string): string {
+        const targetLocale = locale || this._currentLocale;
+        const translation = this.translations[messageCatalogue]?.[targetLocale]?.[key];
+        
+        if (!translation) {
+            console.warn(`Missing translation for key "${key}" in catalogue "${messageCatalogue}" for locale "${targetLocale}"`);
+            return `[MISSING: ${key}]`;
+        }
+        
+        return translation;
+    }
+
+    /** Change page language using URL parameter */
+    async switchLocale(locale: string): Promise<void> {
+        this._currentLocale = locale;
+
+        const url = new URL(this.page.url());
+        url.searchParams.set('ln', locale);
+        await this.page.goto(url.toString());
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    /** Add translation checking to Playwright expect */
+    extendExpect(expect: Expect): Expect<I18nExpected> {
+        const i18nService = this;
+        return expect.extend<I18nExpected>({
+            async toHaveI18nText(
+                locator: Locator, 
+                translationKey: string, 
+                messageCatalogue: string = 'test',
+                options: { locale?: string } = {}
+            ) {
+                const targetLocale = options.locale || i18nService.currentLocale;
+                const expectedText = i18nService.get_localized_text(translationKey, messageCatalogue, targetLocale);
+                
+                if (expectedText.startsWith('[MISSING:')) {
+                    return {
+                        message: () => `Translation key "${translationKey}" not found in catalogue "${messageCatalogue}" for locale "${targetLocale}"`,
+                        pass: false,
+                    };
+                }
+
+                const actualText = await locator.textContent();
+                const pass = actualText?.includes(expectedText) || false;
+
+                return {
+                    message: () => pass 
+                        ? `Expected element not to contain translation "${expectedText}" but it did`
+                        : `Expected element to contain translation "${expectedText}" but got "${actualText}"`,
+                    pass,
+                };
+            },
         });
     }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,7 +1,7 @@
-import { Locators } from '../locators';
 import { I18nServiceInterface, } from './i18n';
+import { Locators } from '../locators';
 import { LoginServiceInterface } from './login';
-export { I18nService, I18nServiceInterface, I18nExpect } from './i18n';
+export { I18nService, I18nServiceInterface, I18nExpected, Translations } from './i18n';
 export { LocalLoginService, LoginServiceInterface } from './login';
 
 export interface Services<L extends Locators> {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { TextCaptureUtil, TextCaptureOptions, TranslatableElement } from './textCapture'; 

--- a/src/utils/textCapture.ts
+++ b/src/utils/textCapture.ts
@@ -1,0 +1,132 @@
+import { Locator, Page } from '@playwright/test';
+
+export interface TextCaptureOptions {
+    minWordLength?: number;
+    wordPattern?: RegExp;
+}
+
+export interface TranslatableElement {
+    locator: Locator;
+    text: string;
+    selector: string;
+}
+
+export class TextCaptureUtil {
+  /** Get all text from page, excluding specified areas */
+  static async capture(
+    page: Page,
+    excludes: string[] = [],
+    options: TextCaptureOptions = {}
+  ): Promise<string[]> {
+    const { minWordLength = 2, wordPattern = /^[a-zA-ZÀ-ÿ]/ } = options;
+
+    return await page.evaluate(
+      (args) => {
+        const { excludes, minWordLength, wordPattern } = args;
+        const clone = document.cloneNode(true) as Document;
+
+        excludes.forEach((selector) => {
+          const elements = clone.querySelectorAll(selector);
+          elements.forEach((el) => el.remove());
+        });
+
+        const allText = clone.body?.textContent || "";
+        const pattern = new RegExp(wordPattern);
+
+        return allText
+          .split(/\s+/)
+          .filter((word) => word.length > minWordLength && pattern.test(word))
+          .filter((word, index, arr) => arr.indexOf(word) === index) 
+          .sort();
+      },
+      {
+        excludes,
+        minWordLength,
+        wordPattern: wordPattern.source,
+      }
+    );
+  }
+
+  /** Find specific UI elements that should have translations */
+  static async findTranslatableElements(
+    page: Page,
+    excludes: string[] = []
+  ): Promise<TranslatableElement[]> {
+    const translatableSelectors = [
+      "nav a:not(:empty)",
+      "nav button:not(:empty)",
+      "nav span:not(:empty)",
+      ".navbar a:not(:empty)",
+      ".navbar button:not(:empty)",
+      ".navbar span:not(:empty)",
+      "header a:not(:empty)",
+      "header button:not(:empty)",
+      "header span:not(:empty)",
+
+      "label:not(:empty)",
+      ".form-label:not(:empty)",
+      "legend:not(:empty)",
+      "button:not(:empty)",
+      'input[type="submit"][value]',
+
+      "h1:not(:empty)",
+      "h2:not(:empty)",
+      "h3:not(:empty)",
+      "h4:not(:empty)",
+      "h5:not(:empty)",
+      "h6:not(:empty)",
+      ".alert:not(:empty)",
+      ".error:not(:empty)",
+      ".warning:not(:empty)",
+      ".success:not(:empty)",
+      ".help-text:not(:empty)",
+      ".tooltip:not(:empty)",
+
+      '[role="menuitem"]:not(:empty)',
+      '[role="tab"]:not(:empty)',
+      '[role="button"]:not(:empty)',
+      ".menu-item:not(:empty)",
+      ".tab-label:not(:empty)",
+      ".btn:not(:empty)",
+    ];
+
+    const elements: TranslatableElement[] = [];
+
+    for (const selector of translatableSelectors) {
+      const locators = page.locator(selector);
+      const count = await locators.count();
+
+      for (let i = 0; i < count; i++) {
+        const locator = locators.nth(i);
+
+        let isInExcludedArea = false;
+        for (const excludeSelector of excludes) {
+          const parentCheck = await locator
+            .locator(
+              `xpath=ancestor-or-self::*[contains(@class, "${excludeSelector.replace(
+                ".",
+                ""
+              )}")][1]`
+            )
+            .count();
+          if (parentCheck > 0) {
+            isInExcludedArea = true;
+            break;
+          }
+        }
+
+        if (!isInExcludedArea && (await locator.isVisible())) {
+          const text = ((await locator.textContent()) || "").trim();
+          if (text.length > 0) {
+            elements.push({
+              locator,
+              text,
+              selector: `${selector}:nth-child(${i + 1})`,
+            });
+          }
+        }
+      }
+    }
+    return elements;
+  }
+} 


### PR DESCRIPTION
## Diff-based approach
Captures all visible text, switches language, compares what changed and tests actual page content, not just marked strings:
```
const beforeTexts = await TextCaptureUtil.capture(page, excludes);
await i18nService.switchLocale('de');

const afterTexts = await TextCaptureUtil.capture(page, excludes);
const unchanged = beforeTexts.filter(word => afterTexts.includes(word));
```
## Fixture-based excludes:

```
Configure in fixtures  
export const test = invenio_test.extend({
    excludes: tugrazExcludes,  // set per repository/institution
});
```

## Test specific UI elements:  
```
await homePage.expectElementTranslations('de', 'invenio-app-rdm-messages');
```

## Message Catalogue implementation:
```
// Hardcoded in I18nService for demo/testing
'invenio-app-rdm-messages': {
    'en': { 'nav.home': 'Home', 'search.placeholder': 'Search records...' },
    'de': { 'nav.home': 'Startseite', 'search.placeholder': 'Datensätze suchen...' }
}
```

_future loading options !?!:_
package-based: query installed packages for entry points, generate JSON registry at build time
API-based: runtime loading via fetch(\\${baseUrl}/api/translations/catalogs\)


### Resulst testing on TUGraz demo:
test case: `tugraz-demo/tests/translation-diff.spec.ts`
<img width="784" height="334" alt="Screenshot 2025-07-23 at 11 36 29" src="https://github.com/user-attachments/assets/c77cfdf7-5839-47a1-ac00-dc32bc8a54d4" />
