### PR TITLE
fix: using translations as a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc; cp package.json dist",
-    "docs": "documentation build src/**/*.ts -f md -o api_docs.md --shallow --github --sort-order kind",
-    "collect-translations": "node scripts/collect-translations.js",
-    "i18n-setup": "node scripts/i18n-setup.js"
+    "build": "tsc; cp package.json dist; cp -r scripts dist/",
+    "docs": "documentation build src/**/*.ts -f md -o api_docs.md --shallow --github --sort-order kind"
+  },
+  "bin": {
+    "invenio-e2e-collect-translations": "scripts/collect-translations.js",
+    "invenio-e2e-i18n-setup": "scripts/i18n-setup.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/collect-translations.js
+++ b/scripts/collect-translations.js
@@ -19,7 +19,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const OUTPUT_DIR = path.join(__dirname, '../src/translations');
+// TODO: consider passing this as an argument
+const OUTPUT_DIR = path.join('translations');
 
 /**
  * Find package in multiple fallback locations.

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -48,22 +48,22 @@ const _test = base.extend<{
     initialLocale: undefined,
 
     // translations loaded from pre-compiled file
-    translations: async ({}, use) => {
-    let translations = {};
-    try {
-        const translationsFile = require('../translations/translations.json');
-        translations = translationsFile;
-    } catch (error) {
-        throw new Error(
-            'Pre-compiled translations not found. Please generate translations first:\n\n' +
-            'run: npm run collect-translations\n' +
-            'or specify packages: npm run collect-translations invenio-app-rdm repository-tugraz\n' +
-            'then rebuild: npm run build\n\n' +
-            'this will create src/translations/translations.json with actual translations from your Invenio packages.\n'
-        );
-    }
-    await use(translations);
-},
+    translations: async ({ }, use) => {
+        let translations = {};
+        try {
+            const translationsFile = require('@collected-translations/translations.json');
+            translations = translationsFile;
+        } catch (error) {
+            throw new Error(
+                'Pre-compiled translations not found. Please generate translations first:\n\n' +
+                'run: npm run collect-translations\n' +
+                'or specify packages: npm run collect-translations invenio-app-rdm repository-tugraz\n' +
+                'then rebuild: npm run build\n\n' +
+                'this will create src/translations/translations.json with actual translations from your Invenio packages.\n'
+            );
+        }
+        await use(translations);
+    },
 
     // untranslated strings for translation testing 
     untranslatedStrings: [],


### PR DESCRIPTION
Thsi fix moves translation scripts from "scripts" to "bin", so that they can be used when invenio-e2e is installed as a library.

collect-translations have been patched to always store the translations to a folder in the pwd, not relative to the script's source dir.